### PR TITLE
test django-allauth PR #3243

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # glitchtip-frontend image includes the glitchtip backend and the frontend
 FROM registry.gitlab.com/glitchtip/glitchtip-frontend:v3.0.4
 USER root
-RUN apt-get update && apt-get install -y patch && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y patch git && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir -U "git+https://github.com/chassing/django-allauth.git@abae97f319a15f987e4695564529c7c1bd9f017d"
 
 USER app:app
 COPY *.patch /code/


### PR DESCRIPTION
https://github.com/pennersr/django-allauth/pull/3242 should fix the empty `user.email` attribute
