### PR TITLE
CI/CD acceptance tests

### DIFF
--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -1,0 +1,14 @@
+FROM quay.io/app-sre/qontract-reconcile
+ARG CONTAINER_UID=1000
+RUN useradd --uid ${CONTAINER_UID} reconcile
+
+WORKDIR /acceptance
+
+COPY requirements-acceptance.txt ./
+RUN python3 -m pip install install --no-cache-dir -r requirements-acceptance.txt
+
+COPY acceptance/ ./
+RUN chown -R reconcile .
+
+USER reconcile
+CMD ["pytest", "-v", "."]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+
+build-acceptance-tests:
+	NO_PUSH=1 ./build_deploy.sh
+
+run-glitchtip:
+	docker-compose -f docker-compose.yml up
+
+run-acceptance-tests-locally: build-acceptance-tests
+	docker run --rm -it --network qontract-development glitchtip-acceptance

--- a/acceptance/conftest.py
+++ b/acceptance/conftest.py
@@ -1,0 +1,54 @@
+import os
+
+import pytest
+from reconcile.utils.glitchtip import GlitchtipClient
+
+
+@pytest.fixture
+def test_org() -> str:
+    return "glitchtip-acceptance-org-12-34-56-78-90"
+
+
+@pytest.fixture
+def test_team() -> str:
+    return "glitchtip-acceptance-team-12-34-56-78-90"
+
+
+@pytest.fixture
+def test_team2() -> str:
+    return "glitchtip-acceptance-team2-12-34-56-78-90"
+
+
+@pytest.fixture
+def test_project() -> str:
+    return "glitchtip-acceptance-project-12-34-56-78-90"
+
+
+@pytest.fixture
+def test_user() -> str:
+    return "glitchtip-acceptance-user-12-34-56-78-90@example.com"
+
+
+@pytest.fixture
+def api_user() -> str:
+    return os.environ.get(
+        "GLITCHTIP_API_USER_EMAIL", "glitchtip@qontract-reconcile.org"
+    )
+
+
+@pytest.fixture
+def glitchtip_client() -> GlitchtipClient:
+    return GlitchtipClient(
+        host=os.environ.get("GLITCHTIP_URL", "http://web:8080"),
+        token=os.environ.get("GLITCHTIP_API_USER_TOKEN", "token"),
+    )
+
+
+@pytest.fixture
+def delete_test_org_before_start(
+    glitchtip_client: GlitchtipClient, test_org: str
+) -> None:
+    """Delete the test organization before starting the tests. Maybe it's left-over from a previous run."""
+    for org in glitchtip_client.organizations():
+        if org.name == test_org:
+            glitchtip_client.delete_organization(org.slug)

--- a/acceptance/test_organizations.py
+++ b/acceptance/test_organizations.py
@@ -1,0 +1,25 @@
+import pytest
+from reconcile.utils.glitchtip import GlitchtipClient
+
+
+def test_organsiation_create(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    delete_test_org_before_start: None,
+) -> None:
+    """Create a new organization."""
+    org = glitchtip_client.create_organization(test_org)
+    assert org.name == test_org
+
+
+@pytest.mark.order(after="test_organsiation_get")
+def test_organsiation_delete(glitchtip_client: GlitchtipClient, test_org: str) -> None:
+    """Delete an organization."""
+    glitchtip_client.delete_organization(test_org)
+
+
+@pytest.mark.order(after="test_organsiation_create")
+def test_organsiation_get(glitchtip_client: GlitchtipClient, test_org: str) -> None:
+    """Get an organization."""
+    orgs = glitchtip_client.organizations()
+    assert [org.name for org in orgs] == [test_org]

--- a/acceptance/test_projects.py
+++ b/acceptance/test_projects.py
@@ -1,0 +1,93 @@
+import pytest
+from reconcile.utils.glitchtip import GlitchtipClient
+
+
+@pytest.mark.order(
+    after=[
+        "test_organizations.py::test_organsiation_create",
+        "test_teams.py::test_team_create",
+    ],
+    before=[
+        "test_organizations.py::test_organsiation_delete",
+        "test_teams.py::test_team_delete",
+    ],
+)
+def test_project_create(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_team: str,
+    test_project: str,
+) -> None:
+    """Create a new project."""
+    glitchtip_client.create_project(
+        test_org, test_team, test_project, platform="python"
+    )
+
+
+@pytest.mark.order(
+    after=["test_project_create"],
+    before=["test_project_delete"],
+)
+def test_project_get(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_project: str,
+) -> None:
+    """Get a project."""
+    projects = glitchtip_client.projects(test_org)
+    assert [test_project] == [project.name for project in projects]
+
+
+@pytest.mark.order(
+    after=["test_project_create"],
+    before=["test_project_delete"],
+)
+def test_project_add_to_team(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_project: str,
+    test_team: str,
+    test_team2: str,
+) -> None:
+    """Add a project to a team."""
+    glitchtip_client.add_project_to_team(test_org, test_team2, test_project)
+    projects = glitchtip_client.projects(test_org)
+    assert [test_team, test_team2] == [
+        team.name for project in projects for team in project.teams
+    ]
+
+
+@pytest.mark.order(
+    after=["test_project_add_to_team"],
+    before=["test_project_delete"],
+)
+def test_project_remove_from_team(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_project: str,
+    test_team: str,
+    test_team2: str,
+) -> None:
+    """Remove a project from a team."""
+    glitchtip_client.add_project_to_team(test_org, test_team2, test_project)
+    projects = glitchtip_client.projects(test_org)
+    assert [test_team, test_team2] == [
+        team.name for project in projects for team in project.teams
+    ]
+
+
+@pytest.mark.order(
+    after=["test_project_create"],
+    before=[
+        "test_organizations.py::test_organsiation_delete",
+        "test_teams.py::test_team_delete",
+    ],
+)
+def test_project_delete(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_team: str,
+    test_project: str,
+) -> None:
+    """Delete a project."""
+    glitchtip_client.delete_project(test_org, test_team, test_project)

--- a/acceptance/test_teams.py
+++ b/acceptance/test_teams.py
@@ -1,0 +1,49 @@
+import pytest
+from reconcile.utils.glitchtip import GlitchtipClient
+
+
+@pytest.mark.order(
+    after=["test_organizations.py::test_organsiation_create"],
+    before=["test_organizations.py::test_organsiation_delete"],
+)
+def test_team_create(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_team: str,
+    test_team2: str,
+) -> None:
+    """Create a new team."""
+    # create two teams to have test add/rm team from project
+    team = glitchtip_client.create_team(test_org, test_team)
+    assert team.name == test_team
+    glitchtip_client.create_team(test_org, test_team2)
+
+
+@pytest.mark.order(
+    after=["test_team_create"],
+    before=["test_team_delete"],
+)
+def test_team_get(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_team: str,
+    test_team2: str,
+) -> None:
+    """Get a team."""
+    teams = glitchtip_client.teams(test_org)
+    assert {test_team, test_team2} == {team.name for team in teams}
+
+
+@pytest.mark.order(
+    after=["test_team_create"],
+    before=["test_organizations.py::test_organsiation_delete"],
+)
+def test_team_delete(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_team: str,
+    test_team2: str,
+) -> None:
+    """Delete a team."""
+    glitchtip_client.delete_team(test_org, test_team)
+    glitchtip_client.delete_team(test_org, test_team2)

--- a/acceptance/test_users.py
+++ b/acceptance/test_users.py
@@ -1,0 +1,110 @@
+import pytest
+from reconcile.utils.glitchtip import GlitchtipClient
+
+
+@pytest.fixture
+def user_pk(glitchtip_client: GlitchtipClient, test_org: str, test_user: str) -> int:
+    """Get a user pk."""
+    users = glitchtip_client.organization_users(test_org)
+    for user in users:
+        if user.email == test_user:
+            assert user.pk is not None
+            return user.pk
+    raise Exception(f"User {test_user} not found in {test_org}")
+
+
+@pytest.mark.order(
+    after=[
+        "test_organizations.py::test_organsiation_create",
+        "test_teams.py::test_team_create",
+    ],
+    before=[
+        "test_organizations.py::test_organsiation_delete",
+        "test_teams.py::test_team_delete",
+    ],
+)
+def test_user_invite(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_user: str,
+) -> None:
+    """Invite a new user."""
+    glitchtip_client.invite_user(test_org, test_user, "member")
+
+
+@pytest.mark.order(
+    after=["test_user_invite"],
+    before=["test_user_delete"],
+)
+def test_user_get(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_user: str,
+    api_user: str,
+) -> None:
+    """Get a user."""
+    users = glitchtip_client.organization_users(test_org)
+    assert set(user.email for user in users) == {api_user, test_user}
+
+
+@pytest.mark.order(
+    after=["test_user_invite"],
+    before=["test_user_delete"],
+)
+def test_user_update_role(
+    glitchtip_client: GlitchtipClient, test_org: str, user_pk: int
+) -> None:
+    """Update user role."""
+    user = glitchtip_client.update_user_role(test_org, "manager", user_pk)
+    assert user.role == "manager"
+
+
+@pytest.mark.order(
+    after=["test_user_invite"],
+    before=["test_user_delete"],
+)
+def test_user_add_to_team(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_team2: str,
+    user_pk: int,
+    test_user: str,
+    api_user: str,
+) -> None:
+    """Add user to a team."""
+    team_users = glitchtip_client.team_users(test_org, test_team2)
+    assert [u.email for u in team_users] == [api_user]
+
+    team = glitchtip_client.add_user_to_team(test_org, test_team2, user_pk)
+    assert {u.email for u in team.users} == {api_user, test_user}
+
+    team_users = glitchtip_client.team_users(test_org, test_team2)
+    assert {u.email for u in team_users} == {api_user, test_user}
+
+
+@pytest.mark.order(
+    after=["test_user_add_to_team"],
+    before=["test_teams.py::test_team_delete", "test_user_delete"],
+)
+def test_user_remove_from_team(
+    glitchtip_client: GlitchtipClient,
+    test_org: str,
+    test_team2: str,
+    user_pk: int,
+    api_user: str,
+) -> None:
+    """Add user to a team."""
+    glitchtip_client.remove_user_from_team(test_org, test_team2, user_pk)
+    team_users = glitchtip_client.team_users(test_org, test_team2)
+    assert [u.email for u in team_users] == [api_user]
+
+
+@pytest.mark.order(
+    after=["test_user_invite"],
+    before=["test_organizations.py::test_organsiation_delete"],
+)
+def test_user_delete(
+    glitchtip_client: GlitchtipClient, test_org: str, user_pk: int
+) -> None:
+    """Delete a user."""
+    glitchtip_client.delete_user(test_org, user_pk)

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,17 +1,29 @@
 #!/bin/bash
-set -exv
+set -ev
 
-BASE_IMG="glitchtip"
-QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
-IMG="${BASE_IMG}:latest"
-GIT_HASH=${GIT_COMMIT:0:7}
+test -z "$NO_PUSH" && docker login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
-# Build Image
-docker build . -t ${IMG}
+for i in "glitchtip Dockerfile" "glitchtip-acceptance Dockerfile.acceptance"
+do
+    set -- $i # convert the "tuple" into the param args $1 $2...
+    IMG_NAME="$1"
+    DOCKERFILE="$2"
 
-# tag and push the image
-docker login  -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-docker tag ${IMG} "${QUAY_IMAGE}:latest"
-docker push "${QUAY_IMAGE}:latest"
-docker tag ${IMG} "${QUAY_IMAGE}:${GIT_HASH}"
-docker push "${QUAY_IMAGE}:${GIT_HASH}"
+    QUAY_IMAGE="quay.io/app-sre/$IMG_NAME"
+    IMG="$IMG_NAME:latest"
+    if [ -n "$GIT_COMMIT" ]; then
+        GIT_HASH=$GIT_COMMIT:0:7
+    fi
+
+    # Build Image
+    echo "Building $IMG_NAME with $DOCKERFILE ..."
+    docker build . -f "$DOCKERFILE" -t "$IMG"
+
+    # Tag and push the image
+    docker tag "$IMG" "$QUAY_IMAGE:latest"
+    test -z "$NO_PUSH" && docker push "$QUAY_IMAGE:latest"
+    if [ -n "$GIT_HASH" ]; then
+        docker tag "$IMG" "$QUAY_IMAGE:$GIT_HASH"
+        test -z "$NO_PUSH" && docker push "$QUAY_IMAGE:$GIT_HASH"
+    fi
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,77 @@
+version: "3.8"
+x-environment: &default-environment
+  DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
+  SECRET_KEY: unsecure
+  ENABLE_ORGANIZATION_CREATION: "true"
+  ENABLE_TEST_API: "true"
+  DEBUG: "true"
+  EMAIL_BACKEND: "django.core.mail.backends.console.EmailBackend"
+  ENABLE_OBSERVABILITY_API: "true"
+  CELERY_WORKER_CONCURRENCY: 1
+  # admin user to login to the admin web UI
+  APPSRE_API_USER_1_EMAIL: "admin@admin.org"
+  APPSRE_API_USER_1_PASSWORD: "rev9tbk!YUE.wfy8uku"
+  # user to use for the API
+  APPSRE_API_USER_2_EMAIL: "glitchtip@qontract-reconcile.org"
+  APPSRE_API_USER_2_TOKEN: "token"
+
+x-depends_on: &default-depends_on
+  - postgres
+  - redis
+
+name: glitchtip-dev
+
+services:
+  postgres:
+    image: postgres:13
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: "trust"
+    restart: unless-stopped
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    networks:
+      - qontract-development
+  redis:
+    image: redis
+    restart: unless-stopped
+    networks:
+      - qontract-development
+  web:
+    image: quay.io/app-sre/glitchtip:latest
+    command:
+      - bin/run-migrate-and-runserver.sh
+    depends_on: *default-depends_on
+    ports:
+      - "8000:8080"
+    environment: *default-environment
+    networks:
+      - qontract-development
+    restart: on-failure
+  worker:
+    image: quay.io/app-sre/glitchtip:latest
+    command:
+      - bin/run-celery-with-beat.sh
+    depends_on: *default-depends_on
+    environment: *default-environment
+    networks:
+      - qontract-development
+    restart: on-failure
+  init-api-users:
+    image: quay.io/app-sre/glitchtip:latest
+    command:
+      - python
+      - appsre/create-api-users.py
+    depends_on: *default-depends_on
+    environment: *default-environment
+    networks:
+      - qontract-development
+    restart: on-failure
+
+volumes:
+  pg-data:
+
+
+networks:
+  qontract-development:
+    external: true
+    name: qontract-development

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -exv
+set -e
 
 # Build Image
 docker build . -t glitchtip:latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+
+[tool.mypy]
+# plugins = "pydantic.mypy"
+enable_error_code = "truthy-bool, redundant-expr"
+no_implicit_optional = true
+check_untyped_defs = true
+warn_unused_ignores = true
+show_error_codes = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+
+[[tool.mypy.overrides]]
+module = ["reconcile.*"]
+ignore_missing_imports = true
+
+[tool.black]
+line-length = 88
+target-version = ['py39']
+include = '^.*\.py$'
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+force_grid_wrap = 2
+float_to_top = true

--- a/requirements-acceptance.txt
+++ b/requirements-acceptance.txt
@@ -1,0 +1,2 @@
+pytest==7.2.*
+pytest-order==1.0.*


### PR DESCRIPTION
* Introduce an additional `glitchtip-acceptance` image to run all acceptance tests
* Testing all important API endpoints used by qontract-reconcile
* Reuse `reconcile.utils.glitchtip.GlitchtipClient`

APPSRE-6862
