### PR TITLE
TASK_DEBOUNCE_DELAY_SECONDS template var

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -24,6 +24,7 @@ objects:
     SECRET_KEY: "${SECRET_KEY}"
     SESSION_COOKIE_AGE: "${SESSION_TIMEOUT_SECONDS}"
     UWSGI_LISTEN: "${UWSGI_LISTEN}"
+    TASK_DEBOUNCE_DELAY: "${TASK_DEBOUNCE_DELAY_SECONDS}"
   metadata:
     annotations:
       qontract.recycle: "true"
@@ -566,6 +567,11 @@ parameters:
 - description: Set the UWSGI socket listen queue size
   name: UWSGI_LISTEN
   value: "128"
+  required: true
+
+- description: Debounce delay for issue update tasks
+  name: TASK_DEBOUNCE_DELAY_SECONDS
+  value: "300"
   required: true
 
 # Populated users


### PR DESCRIPTION
Expose `TASK_DEBOUNCE_DELAY` glitchtip setting. This setting configures the timeframe considering when a task is not executed immediately. Increasing it to 5 minutes should reduce the DB pressure significantly in case of an event flood.

Ticket: [Glitchtip database performance](https://issues.redhat.com/browse/APPSRE-7725)