### PR TITLE
custom uwsgi start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN cat patches/01-automatically-accept-open-inivitations-at-login.patch | patch
 
 # Our appsre custom scripts
 COPY appsre /code/appsre
+COPY bin/* /code/bin/
 
 # ---- Bundle everything together in the final image ----
 FROM base-python as release-glitchtip

--- a/bin/run-uwsgi.sh
+++ b/bin/run-uwsgi.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+set -e
+
+if echo "$PORT" | grep -qF :; then
+    HTTP_SOCKET="$PORT"
+else
+    HTTP_SOCKET=":$PORT"
+fi
+
+UWSGI_LISTEN="${UWSGI_LISTEN:-128}"
+PORT="${PORT:-8000}"
+CHEAPER_OVERLOAD="${UWSGI_CHEAPER_OVERLOAD:-30}"
+MAX_REQUESTS="${UWSGI_MAX_REQUESTS:-10000}"
+WORKER_RELOAD_MERCY="${UWSGI_WORKER_RELOAD_MERCY:-10}"
+
+exec uwsgi \
+    --module=glitchtip.wsgi:application \
+    --env DJANGO_SETTINGS_MODULE=glitchtip.settings \
+    --master --pidfile=/tmp/project-master.pid \
+    --log-x-forwarded-for \
+    --log-format-strftime \
+    --http=$HTTP_SOCKET \
+    --cheaper-algo=busyness \
+    --cheaper-overload=$CHEAPER_OVERLOAD \
+    --cheaper-step=1 \
+    --cheaper-busyness-max=50 \
+    --cheaper-busyness-min=25 \
+    --cheaper-busyness-multiplier=20 \
+    --harakiri=60 \
+    --max-requests=$MAX_REQUESTS \
+    --worker-reload-mercy=$WORKER_RELOAD_MERCY \
+    --die-on-term \
+    --enable-threads \
+    --single-interpreter \
+    --post-buffering \
+    --buffer-size=83146 \
+    --ignore-sigpipe \
+    --ignore-write-errors \
+    --disable-write-exception \
+    --listen=$UWSGI_LISTEN $UWSGI_ARGS

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -21,7 +21,8 @@ objects:
     GLITCHTIP_MAX_EVENT_LIFE_DAYS: "${GLITCHTIP_MAX_EVENT_LIFE_DAYS}"
     SECRET_KEY: "${SECRET_KEY}"
     SESSION_COOKIE_AGE: "${SESSION_TIMEOUT_SECONDS}"
-    UWSGI_LISTEN: "${UWSGI_LISTEN} ${UWSGI_ARGS}"
+    UWSGI_LISTEN: "${UWSGI_LISTEN}"
+    UWSGI_ARGS: "${UWSGI_ARGS}"
     TASK_DEBOUNCE_DELAY: "${TASK_DEBOUNCE_DELAY_SECONDS}"
     MAINTENANCE_EVENT_FREEZE: "${MAINTENANCE_EVENT_FREEZE}"
     MAX_ISSUES_PER_ALERT: "${MAX_ISSUES_PER_ALERT}"
@@ -564,7 +565,7 @@ parameters:
 
 - description: Custom UWSGI args
   name: UWSGI_ARGS
-  value: "--stats /tmp/stats.socket --memory-report"
+  value: "--stats /tmp/stats.socket"
   required: true
 
 - description: Debounce delay for issue update tasks


### PR DESCRIPTION
Override uwsgi start script and start uwsgi in `http` mode instead of `http-socket`. `http` should be used if uwsgi has an haproxy in front and this should solve the `Remote end closed connection without response` issue