### PR TITLE
fix multiple alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ COPY patches /code/patches
 RUN cat patches/00-do-not-send-invitation-emails.patch | patch -p1
 # Accept all open invitations automatically
 RUN cat patches/01-automatically-accept-open-inivitations-at-login.patch | patch -p1
+# Support multiple alerts - https://gitlab.com/glitchtip/glitchtip-backend/-/merge_requests/655
+RUN cat patches/02-support-multiple-alerts.patch | patch -p1
 
 # Our appsre custom scripts
 COPY appsre /code/appsre

--- a/patches/02-support-multiple-alerts.patch
+++ b/patches/02-support-multiple-alerts.patch
@@ -1,0 +1,15 @@
+diff --git a/alerts/tasks.py b/alerts/tasks.py
+index e008668..5c9bbcf 100644
+--- a/alerts/tasks.py
++++ b/alerts/tasks.py
+@@ -27,9 +27,9 @@ def process_event_alerts():
+         issues = (
+             Issue.objects.filter(
+                 project_id=alert.project_id,
+-                notification__isnull=True,
+                 event__created__gte=start_time,
+             )
++            .exclude(notification__project_alert=alert)
+             .annotate(num_events=Count("event"))
+             .filter(num_events__gte=quantity_in_timespan)
+         )


### PR DESCRIPTION
Patch support for multiple alerts on a project. This is an interim solution until the upstream MR [support multiple alerts per project](https://gitlab.com/glitchtip/glitchtip-backend/-/merge_requests/655) has been merged or the new event ingest rewrite is in place.

Ticket: [APPSRE-8673](https://issues.redhat.com/browse/APPSRE-8673)