### PR TITLE
fix import in create-init-users script

### DIFF
--- a/appsre/create-api-users.py
+++ b/appsre/create-api-users.py
@@ -14,7 +14,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "glitchtip.settings")
 django.setup()
 
 from django.contrib.auth.models import AbstractBaseUser  # isort:skip
-from api_tokens.models import APIToken  # isort:skip
+from apps.api_tokens.models import APIToken  # isort:skip
 
 
 @dataclass


### PR DESCRIPTION
the glitchtip django project layout has changed slightly and the `create-init-users.py` needs to be adapted