### PR TITLE
limit issue.tags size to 500kb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ RUN cat patches/00-do-not-send-invitation-emails.patch | patch -p1
 RUN cat patches/01-automatically-accept-open-inivitations-at-login.patch | patch -p1
 # Support multiple alerts - https://gitlab.com/glitchtip/glitchtip-backend/-/merge_requests/655
 RUN cat patches/02-support-multiple-alerts.patch | patch -p1
+# Reduce issue.tags size to 500kb. Upstream don't want to make this configurable, because
+# they are rewriting the event ingest and the DB model. Until then, we need to patch it.
+RUN cat patches/03-limit-tags-size.patch | patch -p1
 
 # Our appsre custom scripts
 COPY appsre /code/appsre

--- a/patches/03-limit-tags-size.patch
+++ b/patches/03-limit-tags-size.patch
@@ -1,0 +1,13 @@
+diff --git a/issues/migrations/sql/functions.py b/issues/migrations/sql/functions.py
+index 983f5bf..27e979e 100644
+--- a/issues/migrations/sql/functions.py
++++ b/issues/migrations/sql/functions.py
+@@ -98,7 +98,7 @@ SET
+   last_seen = GREATEST(event_agg.new_last_seen, issues_issue.last_seen),
+   level = GREATEST(event_agg.new_level, issues_issue.level),
+   search_vector = CASE WHEN pg_column_size(COALESCE(search_vector, ''::tsvector)) < 500000 THEN concat_tsvector(COALESCE(search_vector, ''::tsvector), event_vector.vector) ELSE search_vector END,
+-  tags = CASE WHEN pg_column_size(tags) < 10000000 THEN COALESCE(jsonb_merge_deep(event_agg.new_tags, tags), '{}') ELSE tags END
++  tags = CASE WHEN pg_column_size(tags) < 500000 THEN COALESCE(jsonb_merge_deep(event_agg.new_tags, tags), '{}') ELSE tags END
+ FROM event_agg, event_vector
+ WHERE issues_issue.id = update_issue_id;
+ $$;


### PR DESCRIPTION
A significant `issue.tags` field slows down the `update_issue_index` SQL function performance and drastically harms DB performance. [Upstream](https://gitlab.com/glitchtip/glitchtip-backend/-/issues/298) wants to rewrite the event API and doesn't want to make the size of the tags configurable.