### PR TITLE
[acceptance test] always use latest QR image

### DIFF
--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile:9bf91cf
+FROM quay.io/app-sre/qontract-reconcile:latest
 ARG CONTAINER_UID=1000
 RUN useradd --uid ${CONTAINER_UID} reconcile
 


### PR DESCRIPTION
Update outdated qr image in the acceptance test and always use the latest one to ensure the glitchtip client fits the glitchtip server.

Tickets: 
* [APPSRE-9758](https://issues.redhat.com/browse/APPSRE-9758)
* [APPSRE-9763](https://issues.redhat.com/browse/APPSRE-9763)