### PR TITLE
:bug: grafana: add aws env datasource selector

### DIFF
--- a/grafana/grafana-dashboard.yml
+++ b/grafana/grafana-dashboard.yml
@@ -61,6 +61,7 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -74,6 +75,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -189,9 +191,11 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "10.4.1",
           "targets": [
             {
               "datasource": {
@@ -250,9 +254,11 @@ data:
               "fields": "",
               "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "10.4.1",
           "targets": [
             {
               "datasource": {
@@ -307,8 +313,10 @@ data:
           "interval": "5m",
           "options": {
             "displayMode": "gradient",
+            "maxVizHeight": 300,
             "minVizHeight": 10,
             "minVizWidth": 0,
+            "namePlacement": "auto",
             "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
@@ -317,9 +325,11 @@ data:
               "fields": "",
               "values": false
             },
-            "showUnfilled": true
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "10.4.1",
           "targets": [
             {
               "datasource": {
@@ -336,7 +346,6 @@ data:
             }
           ],
           "title": "Top 10 Issues by Event Rate",
-          "transformations": [],
           "type": "bargauge"
         },
         {
@@ -377,8 +386,10 @@ data:
           "interval": "5m",
           "options": {
             "displayMode": "gradient",
+            "maxVizHeight": 300,
             "minVizHeight": 10,
             "minVizWidth": 0,
+            "namePlacement": "auto",
             "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
@@ -387,9 +398,11 @@ data:
               "fields": "",
               "values": false
             },
-            "showUnfilled": true
+            "showUnfilled": true,
+            "sizing": "auto",
+            "valueMode": "color"
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "10.4.1",
           "targets": [
             {
               "datasource": {
@@ -406,7 +419,6 @@ data:
             }
           ],
           "title": "Top 10 Issues by Event Count",
-          "transformations": [],
           "type": "bargauge"
         },
         {
@@ -420,6 +432,7 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisGridShow": true,
@@ -467,6 +480,7 @@ data:
           "options": {
             "barRadius": 0,
             "barWidth": 0.8,
+            "fullHighlight": false,
             "groupWidth": 1,
             "legend": {
               "calcs": [],
@@ -514,6 +528,7 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisGridShow": true,
@@ -557,6 +572,7 @@ data:
           "options": {
             "barRadius": 0,
             "barWidth": 0.8,
+            "fullHighlight": false,
             "groupWidth": 1,
             "legend": {
               "calcs": [],
@@ -591,7 +607,6 @@ data:
             }
           ],
           "title": "Number of Events per Project",
-          "transformations": [],
           "type": "barchart"
         },
         {
@@ -618,6 +633,7 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -631,6 +647,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -715,6 +732,7 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -728,6 +746,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -819,6 +838,7 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -832,6 +852,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -941,6 +962,7 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
@@ -954,6 +976,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -1094,6 +1117,7 @@ data:
                     "mode": "thresholds"
                   },
                   "custom": {
+                    "axisBorderShow": false,
                     "axisCenteredZero": false,
                     "axisColorMode": "text",
                     "axisLabel": "",
@@ -1107,6 +1131,7 @@ data:
                       "tooltip": false,
                       "viz": false
                     },
+                    "insertNulls": false,
                     "lineInterpolation": "linear",
                     "lineWidth": 1,
                     "pointSize": 5,
@@ -1128,7 +1153,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "#EAB839",
@@ -1148,7 +1174,7 @@ data:
                 "h": 8,
                 "w": 8,
                 "x": 0,
-                "y": 4
+                "y": 44
               },
               "id": 30,
               "options": {
@@ -1205,6 +1231,7 @@ data:
                     "mode": "palette-classic"
                   },
                   "custom": {
+                    "axisBorderShow": false,
                     "axisCenteredZero": false,
                     "axisColorMode": "text",
                     "axisLabel": "",
@@ -1218,6 +1245,7 @@ data:
                       "tooltip": false,
                       "viz": false
                     },
+                    "insertNulls": false,
                     "lineInterpolation": "linear",
                     "lineWidth": 1,
                     "pointSize": 5,
@@ -1239,7 +1267,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -1255,7 +1284,7 @@ data:
                 "h": 8,
                 "w": 8,
                 "x": 8,
-                "y": 4
+                "y": 44
               },
               "id": 31,
               "options": {
@@ -1312,6 +1341,7 @@ data:
                     "mode": "thresholds"
                   },
                   "custom": {
+                    "axisBorderShow": false,
                     "axisCenteredZero": false,
                     "axisColorMode": "text",
                     "axisLabel": "",
@@ -1325,6 +1355,7 @@ data:
                       "tooltip": false,
                       "viz": false
                     },
+                    "insertNulls": false,
                     "lineInterpolation": "linear",
                     "lineWidth": 1,
                     "pointSize": 5,
@@ -1346,7 +1377,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "#EAB839",
@@ -1366,7 +1398,7 @@ data:
                 "h": 8,
                 "w": 8,
                 "x": 16,
-                "y": 4
+                "y": 44
               },
               "id": 32,
               "options": {
@@ -3107,14 +3139,13 @@ data:
         }
       ],
       "refresh": "5m",
-      "schemaVersion": 37,
-      "style": "dark",
+      "schemaVersion": 39,
       "tags": [],
       "templating": {
         "list": [
           {
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "glitchtip",
               "value": "glitchtip"
             },
@@ -3170,6 +3201,23 @@ data:
           {
             "current": {
               "selected": false,
+              "text": "app-sre-prod-04-prometheus",
+              "value": "P3CBCA2291C540C18"
+            },
+            "hide": 2,
+            "includeAll": false,
+            "multi": false,
+            "name": "ds",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "/$env/",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "selected": false,
               "text": "glitchtip-production",
               "value": "glitchtip-production"
             },
@@ -3195,9 +3243,37 @@ data:
           },
           {
             "current": {
+              "selected": true,
+              "text": "prod",
+              "value": "appsrep07ue1-prometheus"
+            },
+            "description": "",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "aws_env",
+            "options": [
+              {
+                "selected": true,
+                "text": "prod",
+                "value": "appsrep07ue1-prometheus"
+              },
+              {
+                "selected": false,
+                "text": "stage",
+                "value": "appsres07ue1-prometheus"
+              }
+            ],
+            "query": "prod : appsrep07ue1-prometheus, stage : appsres07ue1-prometheus",
+            "queryValue": "",
+            "skipUrlSync": false,
+            "type": "custom"
+          },
+          {
+            "current": {
               "selected": false,
-              "text": "app-sre-prod-01-prometheus",
-              "value": "app-sre-prod-01-prometheus"
+              "text": "appsrep07ue1-prometheus",
+              "value": "P7E8E1698DF0AC988"
             },
             "hide": 2,
             "includeAll": false,
@@ -3206,24 +3282,7 @@ data:
             "options": [],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "/app-sre-${env:text}-01-prometheus/",
-            "skipUrlSync": false,
-            "type": "datasource"
-          },
-          {
-            "current": {
-              "selected": false,
-              "text": "app-sre-prod-04-prometheus",
-              "value": "app-sre-prod-04-prometheus"
-            },
-            "hide": 2,
-            "includeAll": false,
-            "multi": false,
-            "name": "ds",
-            "options": [],
-            "query": "prometheus",
-            "refresh": 1,
-            "regex": "/$env/",
+            "regex": "/${aws_env}/",
             "skipUrlSync": false,
             "type": "datasource"
           }
@@ -3237,6 +3296,6 @@ data:
       "timezone": "",
       "title": "Glitchtip Dashboard",
       "uid": "GRUqV30Vk",
-      "version": 14,
+      "version": 15,
       "weekStart": ""
     }


### PR DESCRIPTION
After the switch of aws-resource-exporter to our new HCP cluster, the previous prometheus select logic no longer works.