### PR TITLE
 openshift: run rolling update pod by pod

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -155,6 +155,10 @@ objects:
       matchLabels:
         app.kubernetes.io/component: web
         app.kubernetes.io/name: glitchtip
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 1
     template:
       metadata:
         labels:


### PR DESCRIPTION
Upgrade the web pods pod by pod to have just one `init-migration` running.