### PR TITLE
:sparkles: notification cleanup cronjob

### DIFF
--- a/appsre/cleanup-notifications.py
+++ b/appsre/cleanup-notifications.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+import django
+
+# add the parent directory to the path so we can import the glitchtip module(s)
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Set up Django environment. Must be done before importing any Django DB models.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "glitchtip.settings")
+django.setup()
+
+from apps.alerts.models import Notification  # isort:skip
+
+Notification.objects.all().delete()

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -543,6 +543,81 @@ objects:
             limits:
               memory: ${{GT_WORKER_MEMORY_LIMITS}}
 
+# ---- Notification Cleaner Cron ------
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: glitchtip-notification-cleaner
+    labels:
+      app.kubernetes.io/component: notification-cleaner
+      app.kubernetes.io/name: glitchtip
+
+- apiVersion: batch/v1
+  kind: CronJob
+  metadata:
+    name: glitchtip-notification-cleaner
+    labels:
+      app.kubernetes.io/component: notification-cleaner
+      app.kubernetes.io/name: glitchtip
+  spec:
+    failedJobsHistoryLimit: 1
+    successfulJobsHistoryLimit: 1
+    concurrencyPolicy: Replace
+    schedule: "${NOTIFICATION_CLEANER_SCHEDULE}"
+    jobTemplate:
+      spec:
+        ttlSecondsAfterFinished: 3600
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: notification-cleaner
+              app.kubernetes.io/name: glitchtip
+          spec:
+            serviceAccountName: glitchtip-notification-cleaner
+            restartPolicy: Never
+            containers:
+            - name: notification-cleaner
+              command: ["python3", "appsre/cleanup-notifications.py"]
+              env:
+              - name: SERVER_ROLE
+                value: beat
+              - name: REDIS_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: ${REDIS_SECRET_NAME}
+                    key: redis.url
+              - name: DATABASE_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: ${RDS_SECRET_NAME}
+                    key: db.host
+              - name: DATABASE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: ${RDS_SECRET_NAME}
+                    key: db.password
+              - name: DATABASE_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: ${RDS_SECRET_NAME}
+                    key: db.name
+              - name: DATABASE_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: ${RDS_SECRET_NAME}
+                    key: db.user
+              envFrom:
+                - configMapRef:
+                    name: glitchtip-configmap
+              image: "${IMAGE}:${IMAGE_TAG}"
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  cpu: ${{NOTIFICATION_CLEANER_CPU_REQUESTS}}
+                  memory: ${{NOTIFICATION_CLEANER_MEMORY_REQUESTS}}
+                limits:
+                  memory: ${{NOTIFICATION_CLEANER_MEMORY_LIMITS}}
+
 
 parameters:
 - name: IMAGE
@@ -645,6 +720,10 @@ parameters:
 - description: S3 secret name
   name: S3_SECRET_NAME
   value: glitchtip-s3
+
+- description: Notification cleaner schedule
+  name: NOTIFICATION_CLEANER_SCHEDULE
+  value: "32 4 * * *"
 
 # Populated users
 - name: API_USER_1_EMAIL
@@ -757,5 +836,21 @@ parameters:
 
 - name: BEAT_CPU_REQUESTS
   description: Beat cpu requests
+  value: "100m"
+  required: true
+
+# Notification Cleaner Pod limits
+- name: NOTIFICATION_CLEANER_MEMORY_REQUESTS
+  description: Notification Cleaner memory requests
+  value: "700Mi"
+  required: true
+
+- name: NOTIFICATION_CLEANER_MEMORY_LIMITS
+  description: Notification Cleaner memory limits
+  value: "700Mi"
+  required: true
+
+- name: NOTIFICATION_CLEANER_CPU_REQUESTS
+  description: Notification Cleaner cpu requests
   value: "100m"
   required: true


### PR DESCRIPTION
Glitchtip sends alerts for new issues only once. This PR introduces a cronjob to clean up this "alerts send" cache to enable renotification on recurring issues/events.

Ticket: [APPSRE-10541](https://issues.redhat.com/browse/APPSRE-10541)