### PR TITLE
add team to project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ RUN cat patches/00-do-not-send-invitation-emails.patch | patch -p1
 RUN cat patches/01-automatically-accept-open-inivitations-at-login.patch | patch -p1
 # add https:// to the s3 endpoint url
 RUN cat patches/04-aws-s3-endpoint-url.patch | patch -p1
+# https://gitlab.com/glitchtip/glitchtip-backend/-/merge_requests/1037
+RUN cat patches/05-bug-team-api-fix-add_team_to_project-and-delete_team.patch | patch -p1
 
 # Our appsre custom scripts
 COPY appsre /code/appsre

--- a/acceptance/test_projects.py
+++ b/acceptance/test_projects.py
@@ -50,10 +50,16 @@ def test_project_add_to_team(
     test_team2: str,
 ) -> None:
     """Add a project to a team."""
+    assert test_team2 not in [
+        team.name
+        for project in glitchtip_client.projects(test_org)
+        for team in project.teams
+    ]
     glitchtip_client.add_project_to_team(test_org, test_team2, test_project)
-    projects = glitchtip_client.projects(test_org)
     assert [test_team, test_team2] == [
-        team.name for project in projects for team in project.teams
+        team.name
+        for project in glitchtip_client.projects(test_org)
+        for team in project.teams
     ]
 
 
@@ -69,10 +75,16 @@ def test_project_remove_from_team(
     test_team2: str,
 ) -> None:
     """Remove a project from a team."""
-    glitchtip_client.add_project_to_team(test_org, test_team2, test_project)
-    projects = glitchtip_client.projects(test_org)
-    assert [test_team, test_team2] == [
-        team.name for project in projects for team in project.teams
+    assert test_team2 in [
+        team.name
+        for project in glitchtip_client.projects(test_org)
+        for team in project.teams
+    ]
+    glitchtip_client.remove_project_from_team(test_org, test_team2, test_project)
+    assert test_team2 not in [
+        team.name
+        for project in glitchtip_client.projects(test_org)
+        for team in project.teams
     ]
 
 

--- a/patches/05-bug-team-api-fix-add_team_to_project-and-delete_team.patch
+++ b/patches/05-bug-team-api-fix-add_team_to_project-and-delete_team.patch
@@ -1,0 +1,25 @@
+diff --git a/apps/teams/api.py b/apps/teams/api.py
+index a57f68e1..efa3a74f 100644
+--- a/apps/teams/api.py
++++ b/apps/teams/api.py
+@@ -305,7 +305,7 @@ async def add_team_to_project(
+         Project,
+         slug=project_slug,
+         organization__slug=organization_slug,
+-        organization__users=request.user,
++        organization__users=user_id,
+         organization__organization_users__role__gte=OrganizationUserRole.MANAGER,
+     )
+     team = await aget_object_or_404(
+@@ -340,7 +340,7 @@ async def delete_team_from_project(
+         Project,
+         slug=project_slug,
+         organization__slug=organization_slug,
+-        organization__users=request.user,
++        organization__users=user_id,
+         organization__organization_users__role__gte=OrganizationUserRole.MANAGER,
+     )
+     await project.teams.aremove(team)
+--
+2.45.2
+


### PR DESCRIPTION
Glitchtip 4.0.10+ introduced a [bug](https://gitlab.com/glitchtip/glitchtip-backend/-/merge_requests/1037). Patch it until 4.0.12 has been released.

- **:bug: fix add/delete team to/from project**
- **:white_check_mark: fix tests**
