### PR TITLE
Add http-chunked-input to uwsgi config

### DIFF
--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -5,7 +5,7 @@ RUN useradd --uid ${CONTAINER_UID} reconcile
 WORKDIR /acceptance
 
 COPY requirements-acceptance.txt ./
-RUN python3 -m pip install install --no-cache-dir -r requirements-acceptance.txt
+RUN python3 -m pip install --no-cache-dir -r requirements-acceptance.txt
 
 COPY acceptance/ ./
 RUN chown -R reconcile .

--- a/bin/run-uwsgi.sh
+++ b/bin/run-uwsgi.sh
@@ -24,6 +24,7 @@ exec uwsgi \
     --http-keepalive=$HTTP_KEEPALIVE \
     --http-auto-chunked \
     --add-header="Connection: Close" \
+    --http-chunked-input \
     --cheaper-algo=busyness \
     --cheaper-overload=$CHEAPER_OVERLOAD \
     --cheaper-step=1 \


### PR DESCRIPTION
Fix error

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/uwsgi_chunked/chunked.py", line 83, in __call__
    wsgi_input = BytesIO(chunked.read())
                         ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uwsgi_chunked/chunked.py", line 53, in read
    chunk, self._buffer = self._buffer + self._read(), b''
                                         ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uwsgi_chunked/chunked.py", line 34, in _read
    chunk = self._reader()
            ^^^^^^^^^^^^^^
OSError: unable to receive chunked part
```

[doc](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#http-chunked-input)