### PR TITLE
:bug: create user email address object

### DIFF
--- a/patches/00-skip-user-invitation-process.patch
+++ b/patches/00-skip-user-invitation-process.patch
@@ -1,29 +1,28 @@
 diff --git a/apps/organizations_ext/api.py b/apps/organizations_ext/api.py
-index 49fcfb0e..1adacba6 100644
+index 49fcfb0e..f4c68c4c 100644
 --- a/apps/organizations_ext/api.py
 +++ b/apps/organizations_ext/api.py
-@@ -244,7 +244,32 @@ async def create_organization_member(
+@@ -244,7 +244,31 @@ async def create_organization_member(
      if teams:
          await member.teams.aadd(*teams)
 
 -    await sync_to_async(invitation_backend().send_invitation)(member)
-+    # automatically connect Django user and organization user
++    # automatically create and connect Django user and Glitchtip organization user
 +    from django.contrib.auth import get_user_model
-+    import secrets
-+    import string
++    from allauth.account.models import EmailAddress
 +
-+    alphabet = string.ascii_letters + string.digits
-+    # the user.password field is required but we don't use it.
-+    # just set a random string as password. it's not usable because it's not hashed
-+    unuseble_password = "".join(secrets.choice(alphabet) for i in range(50))
 +    user_model = get_user_model()
-+    await user_model.objects.aget_or_create(
++    user, created = await user_model.objects.aget_or_create(
 +        email=email,
 +        defaults={
-+            "password": unuseble_password,
++            "password": "!",
 +            "is_active": True,
 +        },
 +    )
++    if created:
++        await EmailAddress.objects.aget_or_create(
++            user=user, email=email, primary=True, verified=True
++        )
 +    # Fetch user obj from DB after creation to prefetch socialaccount_set. Needed for API response
 +    user = await user_model.objects.prefetch_related("socialaccount_set").aget(
 +        email=email
@@ -34,20 +33,3 @@ index 49fcfb0e..1adacba6 100644
 +    await member.asave()
 +
      return 201, member
-
-
-diff --git a/glitchtip/settings.py b/glitchtip/settings.py
-index 8e705905..07cdf3f8 100644
---- a/glitchtip/settings.py
-+++ b/glitchtip/settings.py
-@@ -676,6 +676,10 @@ if NEXTCLOUD_URL := env.url("SOCIALACCOUNT_PROVIDERS_nextcloud_SERVER", None):
- if MICROSOFT_TENANT := env.str("SOCIALACCOUNT_PROVIDERS_microsoft_TENANT", None):
-     SOCIALACCOUNT_PROVIDERS["microsoft"] = {"TENANT": MICROSOFT_TENANT}
-
-+SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
-+SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
-+SOCIALACCOUNT_LOGIN_ON_GET = True
-+
- ENABLE_USER_REGISTRATION = env.bool("ENABLE_USER_REGISTRATION", True)
- ENABLE_ORGANIZATION_CREATION = env.bool(
-     "ENABLE_OPEN_USER_REGISTRATION", env.bool("ENABLE_ORGANIZATION_CREATION", False)


### PR DESCRIPTION
The OIDC login and Glitchtip need a valid `allauth.account.models.EmailAddress` object assigned to the Django user. Additionally, the OIDC app (social app) needs these extra settings:

```json
{
  "server_url": "https://IDP_URL/.well-known/openid-configuration", 
  "verified_email": true, 
  "email_authentication": true
}
```