### PR TITLE
glitchtip-notification-cleaner: no cpu limits

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -572,6 +572,8 @@ objects:
   kind: CronJob
   metadata:
     name: glitchtip-notification-cleaner
+    annotations:
+      ignore-check.kube-linter.io/unset-cpu-requirements: "no cpu limits"
     labels:
       app.kubernetes.io/component: notification-cleaner
       app.kubernetes.io/name: glitchtip


### PR DESCRIPTION
Disable `deployment_validation_operator_unset_cpu_requirements` alert for `glitchtip-notification-cleaner` cronjob