### PR TITLE
:bug: fix docker upstream reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # Upstream image (Glitchtip version)
 #
 ARG GLITCHTIP_VERSION=v5.0.9
-ARG GLITCHTIP_IMAGE=registry.gitlab.com/glitchtip/glitchtip-frontend:${GLITCHTIP_VERSION}
-FROM ${GLITCHTIP_IMAGE} AS upstream
+FROM registry.gitlab.com/glitchtip/glitchtip-frontend:${GLITCHTIP_VERSION} AS upstream
 
 
 #


### PR DESCRIPTION
The Konflux build task can't handle nested build arguments anymore.

See this [Slack thread](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1754047171663699) for more details.