### PR TITLE
Fix missing comma in ingest prometheus middleware patch

### DIFF
--- a/patches/08-ingest-prometheus-middleware.patch
+++ b/patches/08-ingest-prometheus-middleware.patch
@@ -6,7 +6,7 @@ index 71aa25d2..a03fce70 100644
                  @classmethod
                  def _get_middleware_setting(cls):
                      return [
-+                        "django_prometheus.middleware.PrometheusBeforeMiddleware"
++                        "django_prometheus.middleware.PrometheusBeforeMiddleware",
                          "django.middleware.security.SecurityMiddleware",
                          "corsheaders.middleware.CorsMiddleware",
                          "glitchtip.middleware.DecompressBodyMiddleware",


### PR DESCRIPTION
Missing trailing comma caused Python implicit string concatenation,
merging `PrometheusBeforeMiddleware` with the next string into a single
invalid module path.
