### PR TITLE
chore(deps): upgrade GlitchTip to 6.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GLITCHTIP_VERSION=6.1.6
+ARG GLITCHTIP_VERSION=6.2.2
 
 #
 # Base image
@@ -10,7 +10,7 @@ FROM registry.access.redhat.com/ubi9/python-314@sha256:e8e9c3b0ee2988e4bddaba0d6
 # and turning this into its own FROM stage makes it show up as a "base image"
 # in the SBOM, which trips the base_image_registries.base_image_permitted
 # Enterprise Contract policy since this registry isn't Red Hat-trusted.
-COPY --from=registry.gitlab.com/glitchtip/glitchtip-frontend:6.1.6 /code/LICENSE /licenses/LICENSE
+COPY --from=registry.gitlab.com/glitchtip/glitchtip-frontend:6.2.2@sha256:3e468993d209e4d296c546c739b2fff20eda7a3ae889a7fa4e77eebccd18411c /code/LICENSE /licenses/LICENSE
 
 ARG GLITCHTIP_VERSION
 ENV GLITCHTIP_VERSION=${GLITCHTIP_VERSION}
@@ -30,7 +30,7 @@ ENV \
     UV_NO_CACHE=true
 
 COPY --from=ghcr.io/astral-sh/uv:0.12.0@sha256:606e70c71c852d03f611b1e56a195d08648507018a7057fab82c4974c4eae105 /uv /bin/uv
-COPY --from=registry.gitlab.com/glitchtip/glitchtip-frontend:6.1.6 --chown=1001:root /code ./
+COPY --from=registry.gitlab.com/glitchtip/glitchtip-frontend:6.2.2@sha256:3e468993d209e4d296c546c739b2fff20eda7a3ae889a7fa4e77eebccd18411c --chown=1001:root /code ./
 
 # Install the required packages
 RUN uv sync --frozen --no-group dev

--- a/patches/08-ingest-prometheus-middleware.patch
+++ b/patches/08-ingest-prometheus-middleware.patch
@@ -1,16 +1,19 @@
 diff --git a/glitchtip/ingest_asgi.py b/glitchtip/ingest_asgi.py
-index 71aa25d2..a03fce70 100644
+index e8bfcc0..d2609b3 100644
 --- a/glitchtip/ingest_asgi.py
 +++ b/glitchtip/ingest_asgi.py
-@@ -48,9 +48,11 @@ class IngestDispatcher:
+@@ -57,12 +57,14 @@ class IngestDispatcher:
                  @classmethod
                  def _get_middleware_setting(cls):
                      return [
 +                        "django_prometheus.middleware.PrometheusBeforeMiddleware",
+                         # async-backend needs explicit per-request cleanup to
+                         # return pool connections; without it the pool
+                         # saturates after max_size requests.
+                         "django_async_backend.middleware.close_async_connections",
                          "django.middleware.security.SecurityMiddleware",
                          "corsheaders.middleware.CorsMiddleware",
-                         "glitchtip.middleware.DecompressBodyMiddleware",
 +                        "django_prometheus.middleware.PrometheusAfterMiddleware",
                      ]
- 
+
                  def load_middleware(self, is_async=True):


### PR DESCRIPTION
## Summary

Upgrades GlitchTip from 6.1.6 to 6.2.2 ([backend CHANGELOG](https://gitlab.com/glitchtip/glitchtip-backend/-/blob/master/CHANGELOG?ref_type=heads)). Replaces the renovate/MintMaker PR #874, whose build was failing because our `08-ingest-prometheus-middleware` patch no longer applied.

- Bump `GLITCHTIP_VERSION` and the `glitchtip-frontend` base image digest to `6.2.2` (same version/digest #874 resolved)
- Regenerate `patches/08-ingest-prometheus-middleware.patch`: upstream restructured the ingest ASGI middleware list in 6.2.0 — dropped `glitchtip.middleware.DecompressBodyMiddleware` (decompression moved to Rust) and added `django_async_backend.middleware.close_async_connections`. Restoring `PrometheusBeforeMiddleware`/`PrometheusAfterMiddleware` around the new list keeps our per-view ingest metrics (used by the KEDA autoscaler) working.
- Patches `00`, `04`, and `09` still apply unchanged against 6.2.2 — verified directly against the upstream 6.2.2 source, no regeneration needed.

## AuthN/AuthZ review

Checked the 6.1.6→6.2.2 changelog for anything auth-relevant, since none of it was called out as needing patch changes:

- 6.1.7: fixed an authz bug (any org admin, not just the caller's own role, could delete projects/DSN keys/teams), OAuth token hashing at rest, cookie `Secure` flag derivation
- 6.2.1: switched to `django-allauth-async` for async auth flows, fixed a social-login bug
- 6.2.2: SSRF bypass fix for uptime monitors/webhooks/importer

None of these touch files we patch. Specifically verified that `from allauth.account.models import EmailAddress` (used by patch `00`) still resolves under `django-allauth-async` — it ships the original `allauth` package unmodified and only adds an `allauth_async` namespace alongside it.

## Test plan

- [x] `docker build --target builder` — all 4 patches apply cleanly against 6.2.2
- [x] `docker build --target prod` — `collectstatic` succeeds
- [x] `docker build --target test` (`make test`) — ruff check, ruff format, mypy all pass
- [x] Compiled and imported all 4 patched files inside the built image; confirmed the `allauth` import works
- [ ] Manual verification in staging after merge (per README checklist: OIDC/SSO login, event ingestion, worker health, Prometheus metrics, KEDA autoscaler, Grafana dashboards)