### PR TITLE
fix(security): move SECRET_KEY and API user credentials into a Kubernetes Secret

### DIFF
--- a/openshift/acceptance.yaml
+++ b/openshift/acceptance.yaml
@@ -12,6 +12,17 @@ objects:
       app.kubernetes.io/component: acceptance-test
       app.kubernetes.io/name: glitchtip
 
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: glitchtip-acceptance-secret
+    labels:
+      app.kubernetes.io/component: acceptance-test
+      app.kubernetes.io/name: glitchtip
+  type: Opaque
+  stringData:
+    GLITCHTIP_API_USER_TOKEN: "${GLITCHTIP_API_USER_TOKEN}"
+
 - apiVersion: batch/v1
   kind: Job
   metadata:
@@ -34,7 +45,10 @@ objects:
               - name: GLITCHTIP_API_USER_EMAIL
                 value: ${GLITCHTIP_API_USER_EMAIL}
               - name: GLITCHTIP_API_USER_TOKEN
-                value: ${GLITCHTIP_API_USER_TOKEN}
+                valueFrom:
+                  secretKeyRef:
+                    name: glitchtip-acceptance-secret
+                    key: GLITCHTIP_API_USER_TOKEN
             resources:
               requests:
                 memory: ${MEMORY_REQUESTS}

--- a/openshift/template.autoscaler.yaml
+++ b/openshift/template.autoscaler.yaml
@@ -19,7 +19,6 @@ objects:
     DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL}
     I_PAID_FOR_GLITCHTIP: "True"
     GLITCHTIP_RETENTION_DAYS: "${GLITCHTIP_MAX_EVENT_LIFE_DAYS}"
-    SECRET_KEY: "${SECRET_KEY}"
     SESSION_COOKIE_AGE: "${SESSION_TIMEOUT_SECONDS}"
     TASK_DEBOUNCE_DELAY: "${TASK_DEBOUNCE_DELAY_SECONDS}"
     MAINTENANCE_EVENT_FREEZE: "${MAINTENANCE_EVENT_FREEZE}"
@@ -40,6 +39,27 @@ objects:
     labels:
       app.kubernetes.io/name: glitchtip
     name: glitchtip-configmap
+
+# -------- SECRET ----------
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      qontract.recycle: "true"
+    labels:
+      app.kubernetes.io/name: glitchtip
+    name: glitchtip-secret
+  type: Opaque
+  stringData:
+    SECRET_KEY: "${SECRET_KEY}"
+    APPSRE_API_USER_1_PASSWORD: "${API_USER_1_PASSWORD}"
+    APPSRE_API_USER_1_TOKEN: "${API_USER_1_TOKEN}"
+    APPSRE_API_USER_2_PASSWORD: "${API_USER_2_PASSWORD}"
+    APPSRE_API_USER_2_TOKEN: "${API_USER_2_TOKEN}"
+    APPSRE_API_USER_3_PASSWORD: "${API_USER_3_PASSWORD}"
+    APPSRE_API_USER_3_TOKEN: "${API_USER_3_TOKEN}"
+    APPSRE_API_USER_4_PASSWORD: "${API_USER_4_PASSWORD}"
+    APPSRE_API_USER_4_TOKEN: "${API_USER_4_TOKEN}"
 
 # ------- WEB DEPLOYMENT --------------------
 - apiVersion: v1
@@ -157,27 +177,51 @@ objects:
           - name: APPSRE_API_USER_1_EMAIL
             value: "${API_USER_1_EMAIL}"
           - name: APPSRE_API_USER_1_PASSWORD
-            value: "${API_USER_1_PASSWORD}"
+            valueFrom:
+              secretKeyRef:
+                name: glitchtip-secret
+                key: APPSRE_API_USER_1_PASSWORD
           - name: APPSRE_API_USER_1_TOKEN
-            value: "${API_USER_1_TOKEN}"
+            valueFrom:
+              secretKeyRef:
+                name: glitchtip-secret
+                key: APPSRE_API_USER_1_TOKEN
           - name: APPSRE_API_USER_2_EMAIL
             value: "${API_USER_2_EMAIL}"
           - name: APPSRE_API_USER_2_PASSWORD
-            value: "${API_USER_2_PASSWORD}"
+            valueFrom:
+              secretKeyRef:
+                name: glitchtip-secret
+                key: APPSRE_API_USER_2_PASSWORD
           - name: APPSRE_API_USER_2_TOKEN
-            value: "${API_USER_2_TOKEN}"
+            valueFrom:
+              secretKeyRef:
+                name: glitchtip-secret
+                key: APPSRE_API_USER_2_TOKEN
           - name: APPSRE_API_USER_3_EMAIL
             value: "${API_USER_3_EMAIL}"
           - name: APPSRE_API_USER_3_PASSWORD
-            value: "${API_USER_3_PASSWORD}"
+            valueFrom:
+              secretKeyRef:
+                name: glitchtip-secret
+                key: APPSRE_API_USER_3_PASSWORD
           - name: APPSRE_API_USER_3_TOKEN
-            value: "${API_USER_3_TOKEN}"
+            valueFrom:
+              secretKeyRef:
+                name: glitchtip-secret
+                key: APPSRE_API_USER_3_TOKEN
           - name: APPSRE_API_USER_4_EMAIL
             value: "${API_USER_4_EMAIL}"
           - name: APPSRE_API_USER_4_PASSWORD
-            value: "${API_USER_4_PASSWORD}"
+            valueFrom:
+              secretKeyRef:
+                name: glitchtip-secret
+                key: APPSRE_API_USER_4_PASSWORD
           - name: APPSRE_API_USER_4_TOKEN
-            value: "${API_USER_4_TOKEN}"
+            valueFrom:
+              secretKeyRef:
+                name: glitchtip-secret
+                key: APPSRE_API_USER_4_TOKEN
           resources:
             requests:
               cpu: ${{GT_WEB_CPU_REQUESTS}}
@@ -262,6 +306,11 @@ objects:
                 name: ${S3_SECRET_NAME}
                 key: endpoint
                 optional: true
+          - name: SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: glitchtip-secret
+                key: SECRET_KEY
           envFrom:
             - configMapRef:
                 name: glitchtip-configmap
@@ -449,6 +498,11 @@ objects:
                 name: ${S3_SECRET_NAME}
                 key: endpoint
                 optional: true
+          - name: SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: glitchtip-secret
+                key: SECRET_KEY
           envFrom:
             - configMapRef:
                 name: glitchtip-configmap
@@ -579,6 +633,11 @@ objects:
                   secretKeyRef:
                     name: ${RDS_SECRET_NAME}
                     key: db.user
+              - name: SECRET_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: glitchtip-secret
+                    key: SECRET_KEY
               envFrom:
                 - configMapRef:
                     name: glitchtip-configmap


### PR DESCRIPTION
## Summary

- Django's `SECRET_KEY` was stored in the `glitchtip-configmap` ConfigMap and the `APPSRE_API_USER_{1..4}_PASSWORD`/`_TOKEN` values were injected into the `init-api-users` initContainer (and `GLITCHTIP_API_USER_TOKEN` into the acceptance Job) as literal `value:` env entries. Both are plaintext-readable by any namespace `view`-role principal via `oc get cm/pod -o yaml`.
- Adds a `glitchtip-secret` Secret to `template.autoscaler.yaml` holding `SECRET_KEY` and all `APPSRE_API_USER_*_PASSWORD`/`_TOKEN` values, consumed via `secretKeyRef` from the web/worker/notification-cleaner containers and the `init-api-users` initContainer.
- Adds a `glitchtip-acceptance-secret` Secret to `acceptance.yaml` for `GLITCHTIP_API_USER_TOKEN`.
- `APPSRE_API_USER_*_EMAIL`, `GLITCHTIP_API_USER_EMAIL`, and `GLITCHTIP_URL` stay as literal values since they aren't credentials.
- **No app-interface changes needed**: `secretParameters` for these exact parameter names are already declared (Vault-backed) in `cicd/saas.yaml` and `cicd/test.yaml`; `oc process` substitutes them into the new `Secret` `stringData` the same way it substituted them into the ConfigMap/literal `value:` fields before.

Fixes findings from the Glasswing security audit: APPSRE-14952 (FIND-001), APPSRE-14953 (FIND-002).

## Test plan

- [x] `oc process --local -f openshift/template.autoscaler.yaml -p ...` — confirmed the ConfigMap no longer contains `SECRET_KEY`, the new `glitchtip-secret` Secret is populated, and web/worker/notification-cleaner/init-api-users all reference it via `secretKeyRef`.
- [x] `oc process --local -f openshift/acceptance.yaml -p ...` — confirmed `glitchtip-acceptance-secret` is populated and the Job references `GLITCHTIP_API_USER_TOKEN` via `secretKeyRef`.
- [x] `make test` (ruff/mypy) — passes; pre-existing mypy errors in `appsre/*.py` are unrelated (missing upstream `apps.*` stubs, not touched by this change).
- [ ] Staging deploy via app-interface promotion pipeline (real end-to-end validation, since there's no local cluster to deploy against).