### PR TITLE
fix(security): disable SA token automount and add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+This repository is a Red Hat AppSRE packaging/deployment layer for [GlitchTip](https://glitchtip.com).
+
+## Reporting a Vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues or pull requests.
+
+To report a security issue in this repository (or in the AppSRE-managed deployment of GlitchTip), contact Red Hat Product Security:
+
+- Email: [secalert@redhat.com](mailto:secalert@redhat.com)
+- PGP key and additional details: <https://access.redhat.com/security/team/contact>
+
+Red Hat Product Security will acknowledge your report and coordinate remediation and disclosure.
+
+For vulnerabilities in upstream GlitchTip itself (unrelated to this packaging repository), please also refer to the [upstream GlitchTip repositories](README.md#what-is-glitchtip).

--- a/openshift/acceptance.yaml
+++ b/openshift/acceptance.yaml
@@ -6,6 +6,7 @@ metadata:
 objects:
 - apiVersion: v1
   kind: ServiceAccount
+  automountServiceAccountToken: false
   metadata:
     name: ${SERVICE_ACCOUNT}
     labels:

--- a/openshift/template.autoscaler.yaml
+++ b/openshift/template.autoscaler.yaml
@@ -64,6 +64,7 @@ objects:
 # ------- WEB DEPLOYMENT --------------------
 - apiVersion: v1
   kind: ServiceAccount
+  automountServiceAccountToken: false
   metadata:
     name: glitchtip-web
     labels:
@@ -371,6 +372,7 @@ objects:
 # --------- WORKER DEPLOYMENT --------------
 - apiVersion: v1
   kind: ServiceAccount
+  automountServiceAccountToken: false
   metadata:
     name: glitchtip-worker
     labels:
@@ -571,6 +573,7 @@ objects:
 # ---- Notification Cleaner Cron ------
 - apiVersion: v1
   kind: ServiceAccount
+  automountServiceAccountToken: false
   metadata:
     name: glitchtip-notification-cleaner
     labels:


### PR DESCRIPTION
## Summary

- Adds `automountServiceAccountToken: false` to all four ServiceAccounts (`glitchtip-web`, `glitchtip-worker`, `glitchtip-notification-cleaner`, `glitchtip-acceptance`). None of these pods call the Kubernetes API, so the projected token was an unnecessary lateral-movement credential available to any RCE in a pod.
- Adds `SECURITY.md` pointing to Red Hat Product Security (`secalert@redhat.com`, `access.redhat.com/security/team/contact`) for vulnerability disclosure.

Fixes findings from the Glasswing security audit: APPSRE-14966 (FIND-007), APPSRE-14968 (FIND-009).

Note: FIND-009's remediation also suggested enabling an OpenSSF Scorecard GitHub Action. No app-sre repo currently uses GitHub Actions (all CI is Konflux/Tekton), so that part is left out of scope here as an org-level decision rather than a per-repo one.

## Test plan

- [x] `oc process --local -f openshift/template.autoscaler.yaml -p ...` — confirmed all three ServiceAccounts render with `automountServiceAccountToken: false`.
- [x] `oc process --local -f openshift/acceptance.yaml -p ...` — confirmed the acceptance ServiceAccount renders with `automountServiceAccountToken: false`.
- [x] `make test` (ruff/mypy) — passes; pre-existing mypy errors in `appsre/*.py` are unrelated (missing upstream `apps.*` stubs, not touched by this change).