### PR TITLE
test: guard against GlitchTip webhook payload drift breaking glitchtip-jira-bridge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,4 +83,12 @@ ENV \
 
 COPY Makefile pyproject.toml ./
 COPY acceptance/ ./acceptance/
+COPY django-tests/ ./django-tests/
+COPY django-tests/test_webhook_payload_contract.py apps/alerts/tests/test_webhook_payload_contract.py
+# Deliberately :latest, unlike the pinned COPY --from= above: this is the
+# real, currently-deployed consumer contract, not a build input -- we want
+# every future build to check against whatever glitchtip-jira-bridge
+# actually expects *right now*, so a contract change over there is caught
+# here too, not just once at the moment this line was written.
+COPY --from=quay.io/redhat-services-prod/app-sre-tenant/glitchtip-jira-bridge-main/glitchtip-jira-bridge-main:latest /opt/app-root/src/glitchtip_jira_bridge/models.py apps/alerts/tests/glitchtip_jira_bridge_models.py
 RUN make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,11 +84,15 @@ ENV \
 COPY Makefile pyproject.toml ./
 COPY acceptance/ ./acceptance/
 COPY django-tests/ ./django-tests/
-COPY django-tests/test_webhook_payload_contract.py apps/alerts/tests/test_webhook_payload_contract.py
-# Deliberately :latest, unlike the pinned COPY --from= above: this is the
-# real, currently-deployed consumer contract, not a build input -- we want
-# every future build to check against whatever glitchtip-jira-bridge
-# actually expects *right now*, so a contract change over there is caught
-# here too, not just once at the moment this line was written.
-COPY --from=quay.io/redhat-services-prod/app-sre-tenant/glitchtip-jira-bridge-main/glitchtip-jira-bridge-main:latest /opt/app-root/src/glitchtip_jira_bridge/models.py apps/alerts/tests/glitchtip_jira_bridge_models.py
+# Directory copy (not per-file) so future django-tests/ additions don't each
+# need a new COPY line here. The line above is still needed separately so
+# ruff/mypy see the files at their own django-tests/ path too.
+COPY django-tests/ apps/alerts/tests/
+# Pinned like the other COPY --from= above so Renovate keeps it current:
+# this is the real, currently-deployed consumer contract, not a static build
+# input, so a Renovate PR bumping this digest is exactly the drift signal we
+# want -- the test re-runs against the new contract right there. (Also
+# avoids indefinite Docker layer-cache staleness that a floating :latest tag
+# would hit.)
+COPY --from=quay.io/redhat-services-prod/app-sre-tenant/glitchtip-jira-bridge-main/glitchtip-jira-bridge-main:latest@sha256:f6d02d77598be866edeaeae442ac59aa2e40cccdd6e63b50c8416b9295a2fc0c /opt/app-root/src/glitchtip_jira_bridge/models.py apps/alerts/tests/glitchtip_jira_bridge_models.py
 RUN make test

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ CONTAINER_ENGINE ?= $(shell which podman >/dev/null 2>&1 && echo podman || echo 
 
 .PHONY: test
 test:
+	@if [ -f manage.py ]; then \
+		DJANGO_SETTINGS_MODULE=glitchtip.settings SECRET_KEY=ci python -m unittest apps.alerts.tests.test_webhook_payload_contract -v; \
+	fi
 	uv run ruff check --no-fix
 	uv run ruff format --check
 	uv run mypy

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ Located in `acceptance/`, run with `pytest`. Tests cover:
 
 Tests run in order (via `pytest-order`) and clean up after themselves.
 
+Only runs as a Job against a real GlitchTip instance
+(`openshift/acceptance.yaml`, wired via app-interface's
+`saas-glitchtip-test` to `glitchtip-stage` after every deploy) — nobody runs
+it locally.
+
 **Environment variables:**
 
 | Variable                   | Default                            | Purpose                    |
@@ -160,6 +165,23 @@ Tests run in order (via `pytest-order`) and clean up after themselves.
 | `GLITCHTIP_URL`            | `http://web:8080`                  | GlitchTip instance URL     |
 | `GLITCHTIP_API_USER_EMAIL` | `glitchtip@qontract-reconcile.org` | API user for test auth     |
 | `GLITCHTIP_API_USER_TOKEN` | `token`                            | Bearer token for API calls |
+
+## Webhook Payload Regression Test
+
+`django-tests/test_webhook_payload_contract.py` guards against upstream
+GlitchTip changing the shape of the JSON it POSTs to webhook alert
+recipients (this bit us once: `glitchtip-jira-bridge` silently rejected
+every alert for months after GlitchTip dropped a field and started omitting
+another). It's a plain `unittest` test against the real, pinned
+`apps/alerts/webhooks.py` — it builds an in-memory `Issue` and mocks only
+the outbound `aiohttp` transport, then asserts on the exact dict that would
+be sent as JSON. It's `COPY`'d into `apps/alerts/tests/` inside the
+Dockerfile's `test` stage and run by `make test`, which Konflux already
+builds on every PR (`.tekton/glitchtip-main-pull-request.yaml`,
+`target-stage: test`) — no live instance or network needed. It's a unit
+test rather than a live E2E acceptance test because there's no network path
+from the real `acceptance` Job (see above) back to a capture endpoint
+without new permanent public-facing infrastructure.
 
 ## Local Development
 

--- a/django-tests/test_webhook_payload_contract.py
+++ b/django-tests/test_webhook_payload_contract.py
@@ -1,0 +1,149 @@
+"""Regression test pinning the real JSON shape GlitchTip sends for a generic webhook alert recipient.
+
+Not part of the upstream glitchtip-backend source: this file is COPY'd into
+the built image inside the Docker `test` stage (see ../Dockerfile) and run
+via `make test`, which Konflux already builds on every PR
+(.tekton/glitchtip-main-pull-request.yaml sets target-stage: test).
+
+Why this exists: glitchtip-jira-bridge had every incoming webhook alert
+silently rejected for months because this exact payload shape drifted
+upstream twice, and nothing anywhere exercised the real serialization code
+and inspected what it actually produces. This test does.
+
+Deliberately NOT a Django TestCase / GlitchTipTestCase: those spin up a
+real Postgres test database before running anything, and none is reachable
+during a plain `docker build` step. Instead this builds unsaved, in-memory
+model instances and mocks the one DB-touching call
+(gather_issue_tags), so the whole test runs via plain `python -m unittest`
+with no database and no network at all.
+
+The consumer contract itself (GlitchtipAlert/Attachment) is imported from
+`glitchtip_jira_bridge_models.py`, which is not written here -- it's the
+real `glitchtip_jira_bridge/models.py`, copied verbatim out of the actual
+deployed consumer image at Docker build time (see ../Dockerfile). So this
+test validates the captured payload against glitchtip-jira-bridge's real,
+currently-deployed pydantic model, not a hand-maintained guess at its shape.
+"""
+
+import os
+import unittest
+from unittest import mock
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "glitchtip.settings")
+os.environ.setdefault("SECRET_KEY", "ci")
+
+import django
+
+django.setup()
+
+from apps.alerts.tests.glitchtip_jira_bridge_models import GlitchtipAlert
+from apps.alerts.webhooks import send_issue_as_webhook
+from apps.issue_events.constants import IssueEventType, LogLevel
+from apps.issue_events.models import Issue
+from apps.organizations_ext.models import Organization
+from apps.projects.models import Project
+
+WEBHOOK_URL = "https://example.invalid/webhook"
+
+
+def _mock_aiohttp_session() -> tuple[mock.MagicMock, mock.MagicMock]:
+    """Build a mock aiohttp.ClientSession that captures session.post() calls."""
+    mock_response = mock.AsyncMock()
+    mock_response.status = 200
+    mock_response.__aenter__ = mock.AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = mock.AsyncMock(return_value=False)
+
+    mock_post = mock.MagicMock(return_value=mock_response)
+
+    mock_session = mock.AsyncMock()
+    mock_session.post = mock_post
+    mock_session.__aenter__ = mock.AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = mock.AsyncMock(return_value=False)
+
+    return mock.MagicMock(return_value=mock_session), mock_post
+
+
+class WebhookPayloadContractTests(unittest.IsolatedAsyncioTestCase):
+    """Pins the real dict `send_issue_as_webhook` posts as JSON.
+
+    GlitchTip's raw-SQL fast path for issue creation
+    (apps/event_ingest/process_event.py::_create_issue_and_hash) hardcodes
+    `culprit` to NULL for every issue, unconditionally, as of v6.2.3. That
+    makes WebhookAttachment.text (== issue.culprit) always None, and
+    WebhookPayload.to_dict() (added in 39a9d4da, "fix: fix support for
+    mattermost webhooks") drops any attachment key whose value is None or
+    [] -- so "text" is always omitted from a real issue-based webhook
+    attachment in this version. If GlitchTip ever starts populating a real
+    culprit again, "text" showing up is a welcome, contract-compatible
+    change for glitchtip-jira-bridge -- relax the assertion below rather
+    than treat it as a failure.
+    """
+
+    def setUp(self) -> None:
+        tags_patcher = mock.patch(
+            "apps.alerts.webhooks.gather_issue_tags",
+            new=mock.AsyncMock(return_value=[]),
+        )
+        tags_patcher.start()
+        self.addCleanup(tags_patcher.stop)
+
+        # Avoids a real DNS lookup for the SSRF guard -- matches the pattern
+        # already used in apps/alerts/tests/test_webhooks.py.
+        url_allowed_patcher = mock.patch(
+            "apps.alerts.webhooks._is_url_allowed",
+            new=mock.AsyncMock(return_value=True),
+        )
+        url_allowed_patcher.start()
+        self.addCleanup(url_allowed_patcher.stop)
+
+        # Issue.level is a read-only proxy onto a related, DB-backed
+        # IssueIndex row (the "hot-split" leaf table) -- irrelevant to this
+        # test's purpose, so it's patched directly rather than faking that
+        # relationship too.
+        level_patcher = mock.patch.object(
+            Issue, "level", new_callable=mock.PropertyMock, return_value=LogLevel.ERROR
+        )
+        level_patcher.start()
+        self.addCleanup(level_patcher.stop)
+
+        organization = Organization(name="Acceptance Org", slug="acceptance-org")
+        project = Project(
+            organization=organization,
+            name="Acceptance Project",
+            slug="acceptance-project",
+        )
+        self.issue = Issue(
+            project=project,
+            title="ZeroDivisionError: division by zero",
+            culprit=None,
+            type=IssueEventType.ERROR,
+            metadata={},
+        )
+        self.issue.pk = 1
+
+    async def test_real_issue_webhook_payload_matches_jira_bridge_contract(
+        self,
+    ) -> None:
+        mock_constructor, mock_post = _mock_aiohttp_session()
+        with mock.patch("aiohttp.ClientSession", mock_constructor):
+            await send_issue_as_webhook(WEBHOOK_URL, [self.issue], 1)
+
+        mock_post.assert_called_once()
+        payload = mock_post.call_args.kwargs["json"]
+
+        # The actual proof this test exists for: does glitchtip-jira-bridge's
+        # real, currently-deployed pydantic model accept this payload at all?
+        # Raises pydantic.ValidationError (failing the test) if not.
+        alert = GlitchtipAlert(**payload)
+        assert alert.attachments[0].title
+        assert alert.attachments[0].title_link
+
+        # GlitchtipAlert(**payload) alone can't distinguish "text omitted"
+        # from "text explicitly null" -- both parse to attachments[0].text is
+        # None. Pinning current, always-true (as of v6.2.3) behavior -- see
+        # class docstring -- needs the raw dict.
+        assert "text" not in payload["attachments"][0]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/django-tests/test_webhook_payload_contract.py
+++ b/django-tests/test_webhook_payload_contract.py
@@ -135,14 +135,19 @@ class WebhookPayloadContractTests(unittest.IsolatedAsyncioTestCase):
         # real, currently-deployed pydantic model accept this payload at all?
         # Raises pydantic.ValidationError (failing the test) if not.
         alert = GlitchtipAlert(**payload)
-        assert alert.attachments[0].title
-        assert alert.attachments[0].title_link
+        assert alert.attachments[0].title, f"title must never be empty: {payload!r}"
+        assert alert.attachments[0].title_link, (
+            f"title_link must never be empty: {payload!r}"
+        )
 
         # GlitchtipAlert(**payload) alone can't distinguish "text omitted"
         # from "text explicitly null" -- both parse to attachments[0].text is
         # None. Pinning current, always-true (as of v6.2.3) behavior -- see
         # class docstring -- needs the raw dict.
-        assert "text" not in payload["attachments"][0]
+        assert "text" not in payload["attachments"][0], (
+            f"expected 'text' to be omitted from a real issue-based "
+            f"attachment (see class docstring), got: {payload['attachments'][0]!r}"
+        )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,12 @@ dev = [
 # Ruff configuration
 [tool.ruff]
 line-length = 88
-include = ["acceptance/*.py", "appsre/*.py", "**/pyproject.toml"]
-src = ["acceptance", "appsre"]
+# Without this, `uv run ruff check` inside the Docker `test` stage (see
+# Dockerfile) lints the whole vendored GlitchTip source tree copied into
+# $APP_ROOT, not just this repo's own files -- restrict to what we actually
+# own.
+include = ["acceptance/*.py", "appsre/*.py", "django-tests/*.py", "**/pyproject.toml"]
+src = ["acceptance", "appsre", "django-tests"]
 extend-exclude = [
     # exclude some common cache and tmp directories
     ".local",
@@ -92,7 +96,7 @@ known-first-party = ["acceptance", "appsre"]
 
 # Mypy configuration
 [tool.mypy]
-files = ["appsre", "acceptance"]
+files = ["appsre", "acceptance", "django-tests"]
 plugins = ["pydantic.mypy"]
 enable_error_code = ["truthy-bool", "redundant-expr"]
 no_implicit_optional = true
@@ -107,4 +111,19 @@ follow_imports = "silent"
 # Below are all of the packages that don't implement stub packages. Mypy will throw an error if we don't ignore the
 # missing imports. See: https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 module = ["reconcile.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# glitchtip-backend's own Django app code -- only present inside the built
+# image (see Dockerfile's `test` stage), not installed in this repo's venv.
+# Scoped to only what django-tests/ actually imports, rather than all of
+# apps.* -- a blanket apps.* ignore would mask real type errors elsewhere
+# under appsre/ (e.g. apps.api_tokens) that only surface when that code
+# actually resolves, inside the real Docker build.
+module = [
+    "apps.alerts.*",
+    "apps.issue_events.*",
+    "apps.organizations_ext.*",
+    "apps.projects.*",
+]
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- `glitchtip-jira-bridge` had every incoming webhook alert silently rejected for months because GlitchTip's webhook payload shape drifted upstream twice, and nothing anywhere exercised the real serialization code (`apps/alerts/webhooks.py`) and inspected what it actually produces.
- Adds `django-tests/test_webhook_payload_contract.py`, a `unittest` against the real, pinned GlitchTip source (v6.2.3): builds an in-memory `Issue`, mocks only the outbound `aiohttp` transport, then validates the exact dict that would be sent as JSON against `GlitchtipAlert`/`Attachment` — copied verbatim out of the actual deployed `glitchtip-jira-bridge` image at Docker build time, pinned by digest (`COPY --from=quay.io/.../glitchtip-jira-bridge-main:latest@sha256:...`) like every other `COPY --from=` in this file, not a hand-maintained guess at its shape. Renovate keeps the digest current; a bump PR is the drift signal.
- `COPY`'d (whole `django-tests/` directory, so future additions don't need a new Dockerfile line) into `apps/alerts/tests/` inside the Dockerfile's existing `test` stage and run via `make test`, which Konflux already builds on every PR (`target-stage: test`) — no live instance, no network, no new infrastructure needed.
- Why not a live E2E acceptance test: `acceptance/` only ever runs as a Job against the real `glitchtip-stage` OpenShift namespace, and there's no network path from that Job back to a capture endpoint without new permanent public-facing infrastructure.

## Test plan
- [x] `docker build --target test` — the exact stage Konflux builds on every PR — passes: new unittest, ruff, ruff format, and mypy all green.
- [x] Verified against the real, currently-deployed `glitchtip-jira-bridge` image (PR app-sre/glitchtip-jira-bridge#756, merged) — payload parses via `GlitchtipAlert(**payload)`.
- [x] Addressed review feedback from @hemslo: directory-copy Dockerfile line, digest-pinned `COPY --from=`, and failure messages on the bare `assert`s (kept bare per this repo's ruff PT009 rule).

Ref: APPSRE-15061